### PR TITLE
Delete from _.channels on unsubscribe.

### DIFF
--- a/dist/pusher-test-stub.js
+++ b/dist/pusher-test-stub.js
@@ -102,7 +102,7 @@ var PusherTestStub =
 	};
 
 	PusherTestStub.prototype.unsubscribe = function(channelName) {
-	  
+	  delete this._channels[channelName];
 	};
 
 	PusherTestStub.prototype.channel = function(channelName) {

--- a/src/PusherTestStub.js
+++ b/src/PusherTestStub.js
@@ -55,7 +55,7 @@ PusherTestStub.prototype._channelFactory = function(channelName, options) {
 };
 
 PusherTestStub.prototype.unsubscribe = function(channelName) {
-  
+  delete this._channels[channelName];
 };
 
 PusherTestStub.prototype.channel = function(channelName) {


### PR DESCRIPTION
Pusher's internal `unsubscribe()` calls `channels.remove()` - [link](https://github.com/pusher/pusher-js/blob/0eff765/src/pusher.js#L196)

This PR adds a `delete this._channels[channelName];` to mimic this behavior.

I made this PR against the `2.0.0` branch, let me know if you'd prefer another one.

P.S. Thanks a ton for creating this library.